### PR TITLE
Groovy output browser

### DIFF
--- a/plugins/org.orbisgis.groovyeditor/plugin.xml
+++ b/plugins/org.orbisgis.groovyeditor/plugin.xml
@@ -74,7 +74,6 @@
               description="Add jar to classPath"
               id="org.orbisgis.ui.editors.groovy.addJarToClasspath"
               name="Add jar to classPath"> </command>
-
    </extension>
 
    <extension point="org.eclipse.ui.commandImages">
@@ -128,17 +127,29 @@
       </handler>
    </extension>
 
-    <extension point="org.eclipse.ui.views">
-        <view
-                id="org.jkiss.dbeaver.groovy.output"
-                class="org.orbisgis.ui.editors.groovy.GroovyOutputConsole"
-                allowMultiple="true"
-                restorable="true"
-                name="Groovy Output"
-				icon="icons/groovy_output.png"
-		>
-        </view>
-    </extension>
+   <extension point="org.eclipse.ui.views">
+      <view
+              id="org.jkiss.dbeaver.groovy.output"
+              class="org.orbisgis.ui.editors.groovy.GroovyOutputConsole"
+              allowMultiple="true"
+              restorable="true"
+              name="Groovy Output"
+              icon="icons/groovy_output.png"
+      >
+      </view>
+   </extension>
+
+   <extension point="org.eclipse.ui.views">
+      <view
+              id="org.jkiss.dbeaver.groovy.outputBrowser"
+              class="org.orbisgis.ui.editors.groovy.GroovyOutputBrowser"
+              allowMultiple="false"
+              restorable="true"
+              name="Groovy Output Browser"
+              icon="icons/groovy_output.png"
+      >
+      </view>
+   </extension>
 
    <extension
          point="org.eclipse.ui.editors">

--- a/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyEditorControl.java
+++ b/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyEditorControl.java
@@ -26,15 +26,13 @@ public class GroovyEditorControl extends Composite {
 
     private final GroovyEditor editor;
 
-    public GroovyEditorControl(Composite parent, GroovyEditor editor)
-    {
+    public GroovyEditorControl(Composite parent, GroovyEditor editor) {
         super(parent, SWT.NONE);
         this.editor = editor;
         setLayout(new FillLayout());
     }
 
-    public GroovyEditor getEditor()
-    {
+    public GroovyEditor getEditor() {
         return editor;
     }
 }

--- a/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyJob.java
+++ b/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyJob.java
@@ -18,11 +18,9 @@
  */
 package org.orbisgis.ui.editors.groovy;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.net.URLClassLoader;
-import java.time.format.DateTimeFormatter;
-
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import groovy.transform.ThreadInterrupt;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.codehaus.groovy.control.customizers.ASTTransformationCustomizer;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -33,9 +31,9 @@ import org.orbisgis.core.logger.Logger;
 import org.orbisgis.ui.editors.groovy.GroovyOutputConsole.GroovyConsoleContent;
 import org.orbisgis.ui.editors.groovy.logger.GroovyLogger;
 
-import groovy.lang.Binding;
-import groovy.lang.GroovyShell;
-import groovy.transform.ThreadInterrupt;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URLClassLoader;
 
 public class GroovyJob extends Job {
 
@@ -46,8 +44,6 @@ public class GroovyJob extends Job {
     private Binding binding;
     private String name;
     private Thread t;
-    DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
-    PrintWriter outputPrintWriter = null;
 
     public GroovyJob(String name, String script) {
         super(name);
@@ -56,7 +52,8 @@ public class GroovyJob extends Job {
         binding = new Binding();
         binding.setProperty("logger", new GroovyLogger(GroovyShell.class));
         binding.setProperty("out", new StringWriter());
-        
+        binding.setProperty("browser", GroovyOutputBrowser.browserHandler);
+
         CompilerConfiguration configuratorConfig = new CompilerConfiguration(System.getProperties());
         configuratorConfig.addCompilationCustomizers(new ASTTransformationCustomizer(ThreadInterrupt.class));
    

--- a/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyOutputBrowser.java
+++ b/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyOutputBrowser.java
@@ -1,0 +1,58 @@
+/*
+ * Groovy Editor (GE) is a library that brings a groovy console to the Eclipse RCP.
+ * GE is developed by CNRS http://www.cnrs.fr/.
+ *
+ * GE is part of the OrbisGIS project. GE is free software;
+ * you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation;
+ * version 3.0 of the License.
+ *
+ * GE is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+ * for more details http://www.gnu.org/licenses.
+ *
+ *
+ *For more information, please consult: http://www.orbisgis.org
+ *or contact directly: info_at_orbisgis.org
+ *
+ */
+package org.orbisgis.ui.editors.groovy;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.browser.Browser;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.part.ViewPart;
+import org.jkiss.dbeaver.ui.UIUtils;
+
+/**
+ * Methods which are able to print the groovy standard output in a specific groovy console.
+ *
+ * @author Adrien Bessy, CNRS
+ */
+public class GroovyOutputBrowser extends ViewPart {
+	private static Browser browser = null;
+	public static BrowserHandler browserHandler = new BrowserHandler();
+
+	@Override
+	public void createPartControl(Composite parent) {
+		Composite group = UIUtils.createPlaceholder(parent, 1);
+		group.setLayout(new FillLayout());
+		browser = new Browser(group, SWT.V_SCROLL | SWT.H_SCROLL);
+		browser.setText("Nothing to show.");
+	}
+
+	@Override
+	public void setFocus() {
+	}
+
+	private static class BrowserHandler {
+		public void setText(String html) {
+			Display.getDefault().asyncExec(()->{
+				browser.setText(html);
+			});
+		}
+	}
+}


### PR DESCRIPTION
Add an output browser for groovy, which is passed to the script into the bindings.

The browser is shown using the menu `windows/shows view/other`, and in the popup open `other/Groovy Output Browser`.
For now, only one single browser can be shown.

An handler for this browser is pass through the script bindings under the name `browser`.
This handler has the `setText(String)` methods because it should call `Display.getCurrent().asyncExec(...)` in order to update the SWT composite in the good thread.

An example of non working Demat script (the browser is not able to find the vega javascripts, so @ebocher if you want to fix it...)
```groovy
@GrabResolver(name='orbisgis', root='https://oss.sonatype.org/content/repositories/snapshots')
@Grab(group='org.orbisgis', module='demat', version='0.0.7-SNAPSHOT')

import static org.orbisgis.demat.Plot.*
def chart = Chart(Data([
                ["a": "A", "b": 28], ["a": "B", "b": 55], ["a": "C", "b": 43],
                ["a": "D", "b": 91], ["a": "E", "b": 81], ["a": "F", "b": 53],
                ["a": "G", "b": 19], ["a": "H", "b": 87], ["a": "I", "b": 52]])).mark_bar().
                encode(X("a").nominal(), Y("b").quantitative())
chart.show()

def file = new File("/tmp/tempChart.html")
chart.save(file, true) 
browser.setText(file.text)

```