### PR TITLE
New features about opening/closing symbols

### DIFF
--- a/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyEditor.java
+++ b/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyEditor.java
@@ -59,7 +59,10 @@ public class GroovyEditor extends AbstractDecoratedTextEditor implements ISaveab
     }
 
     /**
-     * Catch the last pressed key, if it is an opening symbol like ([{"', the corresponding closing symbol is written automatically after the cursor.
+     * Catch the last pressed key, if it is an opening symbol like ([{"', the corresponding closing symbol is written
+     * automatically after the cursor.
+     * If the deleted key is pressed : if the deleted character is an opening symbol like ([{"' and if the following
+     * character is its corresponding closing symbol, so this corresponding closing symbol is also deleted.
      * @param parent the composite
      * @param ruler the iVerticalRuler
      * @param styles the styles
@@ -88,6 +91,25 @@ public class GroovyEditor extends AbstractDecoratedTextEditor implements ISaveab
                     case "'":
                         styledText.insert("'");
                         break;
+                }
+
+                // if the delete key is pressed
+                if (verifyEvent.keyCode == 8) {
+                    int caretOffset = styledText.getCaretOffset();
+                    String source = ((StyledText) verifyEvent.getSource()).getText();
+                    // if there is a character after the cursor and if the delete key is not pressed at the first
+                    // possible position of the caret
+                    if(caretOffset < source.length() && caretOffset != 0) {
+                        String deletedCharacter = String.valueOf(source.charAt(caretOffset - 1));
+                        String followingCharacter = String.valueOf(source.charAt(caretOffset));
+                        if (deletedCharacter.equals("(") && followingCharacter.equals(")")
+                                || deletedCharacter.equals("[") && followingCharacter.equals("]")
+                                || deletedCharacter.equals("{") && followingCharacter.equals("}")
+                                || deletedCharacter.equals("\"") && followingCharacter.equals("\"")
+                                || deletedCharacter.equals("'") && followingCharacter.equals("'")) {
+                            styledText.replaceTextRange(caretOffset,1,"");
+                        }
+                    }
                 }
             });
         }

--- a/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyEditor.java
+++ b/plugins/org.orbisgis.groovyeditor/src/org/orbisgis/ui/editors/groovy/GroovyEditor.java
@@ -186,6 +186,14 @@ public class GroovyEditor extends AbstractDecoratedTextEditor implements ISaveab
                             }
                         }
                     }
+                    if (caretOffset < source.length() && caretOffset != 0) {
+                        String followingCharacter = String.valueOf(source.charAt(caretOffset));
+                        if(followingCharacter.equals(lastCharacter) && followingCharacter.equals(")")
+                        || followingCharacter.equals(lastCharacter) && followingCharacter.equals("]")
+                        || followingCharacter.equals(lastCharacter) && followingCharacter.equals("}")){
+                            styledText.replaceTextRange(caretOffset, 1, "");
+                        }
+                    }
                 }else {
                     // if we type a double quotation mark and if the following character is also a double quotation mark,
                     // the cursor will go to the next position without inserting anything more.


### PR DESCRIPTION
If the deleted character is an opening symbol like (, [, {, " or ' and if the following character is its corresponding closing symbol, so this corresponding closing symbol is also deleted.
Don't insert automatically closing symbol when opening symbol is typed between double quotation marks.
Don't delete automatically closing symbol when opening symbol is deleted between double quotation marks.
Take into account the double quotation marks in the simple ones.
If a closing symbol is typed and if the following character is also this closing symbol, the cursor will go to the next position without inserting anything more.
@ebocher @SPalominos 